### PR TITLE
Correct a typo with z-index

### DIFF
--- a/property/z-index/index.html
+++ b/property/z-index/index.html
@@ -14,7 +14,7 @@ property_name: z-index
       <a href="{{site.url}}/#z-index"><span>#</span>z-index</a>
     </h2>
     <div class="property-description">
-      <p>Defines the <strong>order</strong> of the elements on the <strong>z-axis*8. It only works on </strong>positioned** elements (anything apart from <code>static</code>).</p>
+      <p>Defines the <strong>order</strong> of the elements on the <strong>z-axis</strong>. It only works on <strong>positioned</strong> elements (anything apart from <code>static</code>).</p>
 
     </div>
 


### PR DESCRIPTION
This PR fixes a Markdown typo with z-index, where `strong` tags ended up out of place.