### PR TITLE
Change hsl()a to hsla() to match rgba()

### DIFF
--- a/property/color/index.html
+++ b/property/color/index.html
@@ -162,7 +162,7 @@ property_name: color
           <code class="example-value" data-tooltip="Click to copy" data-clipboard-text="color: hsla(14, 100%, 53%, 0.6);">color: hsla(14, 100%, 53%, 0.6);</code>
         </p>
         <div class="example-description">
-          <p>You can use <strong>hsl()a</strong> color codes:</p>
+          <p>You can use <strong>hsla()</strong> color codes:</p>
 <ul><li>the first 3 values are for <code>hsl</code></li><li>the 4th value is for the <code>alpha</code> channel and defines the opacity of the color</li></ul><p>The alpha value can go from zero <strong>0</strong> (transparent) to one <strong>1</strong> (opaque).</p>
 
         </div>


### PR DESCRIPTION
I didn't find anything saying this was intentional so I made a quick patch.

http://cssreference.io/#color

See `rgb()` and `rgba()` as compared to `hsl()` and `hsl()a`