### PR TITLE
Fix for border-radius two-value shorthand

### DIFF
--- a/property/border-radius/index.html
+++ b/property/border-radius/index.html
@@ -97,7 +97,7 @@ property_name: border-radius
           <code class="example-value" data-tooltip="Click to copy" data-clipboard-text="border-radius: 20px 50%;">border-radius: 20px 50%;</code>
         </p>
         <div class="example-description">
-          <p>If you set <strong>two values</strong>, the first one is for the <em>top</em> and <em>bottom</em> borders, the second one for the <em>left</em> and <em>right</em> borders.</p>
+          <p>If you set <strong>two values</strong>, the first one is for the <em>top-left</em> and <em>bottom-right</em> corners, and the second one is for the <em>bottom-left</em> and <em>top-right</em> corners.</p>
 
         </div>
       </header>


### PR DESCRIPTION
Weird I know, but when you specify two values you're telling it how to style the top-left/bottom-right corners, and the bottom-left/top-right corners.