### PR TITLE
Fix: typo on fadeAndMove definition

### DIFF
--- a/property/animation-play-state/index.html
+++ b/property/animation-play-state/index.html
@@ -72,7 +72,7 @@ property_name: animation-play-state
     transform: translateX(0);
   }
   to {
-    opacity: 0;
+    opacity: 1;
     transform: translateX(100px);
   }
 }</pre></p>


### PR DESCRIPTION
According to the `animation-play-state: running;` animation, the final opacity on the `@keyframes` definition should be 1.